### PR TITLE
fix(style.scss): update style to remove side nav and fix github button

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -101,6 +101,7 @@ body {
     }
 
     .fork {
+	  background: none;
       position: relative !important;
       background-color: $color-pig-day;
       padding-top: 14px;
@@ -130,6 +131,7 @@ body {
     }
 
     nav {
+	  display: none;
       width: $menu-width;
       margin-left: $side-margin-left;
       top: 110px;


### PR DESCRIPTION
The side nav has now been removed as it doesn't make sense to show all
the links within the guide pages. The github button gradient background
has also been removed.